### PR TITLE
fix: make sure to overrite existing files when moving artifacts.

### DIFF
--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -2,10 +2,10 @@ import { qwikVite } from '@builder.io/qwik/optimizer';
 import { getQwikLoaderScript } from '@builder.io/qwik/server';
 import { build } from 'vite';
 
-import { mkdir, readdir, rename } from "node:fs/promises";
-import { createReadStream, rmSync } from "node:fs";
-import { createInterface } from "node:readline";
-import { join, relative } from "node:path";
+import { mkdir, readdir } from 'node:fs/promises';
+import { createReadStream, rmSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { join, relative } from 'node:path';
 
 import type { AstroConfig, AstroIntegration } from 'astro';
 
@@ -171,10 +171,10 @@ async function getQwikEntrypoints(dir: string): Promise<string[]> {
     let builderFound = false;
     let found = false;
     for await (const line of rl) {
-      if (line.includes("import")) {
+      if (line.includes('import')) {
         importFound = true;
       }
-      if (line.includes("@builder.io/qwik")) {
+      if (line.includes('@builder.io/qwik')) {
         builderFound = true;
       }
       if (importFound && builderFound) {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -2,7 +2,7 @@ import { qwikVite } from '@builder.io/qwik/optimizer';
 import { getQwikLoaderScript } from '@builder.io/qwik/server';
 import { build } from 'vite';
 
-import { mkdir, readdir } from 'node:fs/promises';
+import { copyFile, lstat, mkdir, readdir, unlink } from 'node:fs/promises';
 import { createReadStream, rmSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { join, relative } from 'node:path';


### PR DESCRIPTION
When trying to integrate into an existing site with more image file, I ran into an issue in the build where files weren't being copied over and deleted properly.

This PR makes sure to overwrite existing files.