### PR TITLE
fix: ignore error while renaming artifacts

### DIFF
--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -114,8 +114,13 @@ function hash() {
 
 async function moveArtifacts(srcDir: string, destDir: string) {
   await mkdir(destDir, { recursive: true });
-  for (const file of await readdir(srcDir)) {
-    await rename(join(srcDir, file), join(destDir, file));
+
+  try {
+    for (const file of await readdir(srcDir)) {
+      await rename(join(srcDir, file), join(destDir, file));
+    }
+  } catch {
+    // ignore error if directory not empty
   }
 }
 


### PR DESCRIPTION
![3lCKADMn 2023-11-13 at 12 33 PM@2x](https://github.com/QwikDev/astro/assets/45778229/79d10100-5672-484b-b5c2-bc06776377f7)

Currently when `astro:build:done` and running the `moveArtifacts` it throws an error, I'm not sure how to reproduce it, but it works fine after adding the `try/catch`