### PR TITLE
unique dir, tempDir change, moveArtifacts refactor

### DIFF
--- a/libs/qwikdev-astro/package.json
+++ b/libs/qwikdev-astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwikdev/astro",
   "description": "Use Qwik components and Resumability within Astro",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "contributors": [
     {
       "name": "Miško Hevery",


### PR DESCRIPTION
This PR improves moveArtifacts to relocate conflicts to a unique local directory.

`moveArtifacts` is a function that transfers files from a source directory to a destination directory. If a conflict arises (a file with the same name exists), it either creates a new unique directory for directories or overwrites for files.

`getUniqueTempDir` generates this unique directory path.

We get `tempDir` from our `getUniqueTempDir` function.