### PR TITLE
:recycle: Move 'fs-extra' to Production Dependencies

### DIFF
--- a/libs/qwikdev-astro/package.json
+++ b/libs/qwikdev-astro/package.json
@@ -49,12 +49,14 @@
     "access": "public"
   },
   "bugs": "https://github.com/thejackshelton/@qwikdev/astro/issues",
+  "dependencies": {
+    "fs-extra": "^11.1.1"
+  },
   "devDependencies": {
     "@builder.io/qwik": "^1.2.17",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.8.9",
     "astro": "^3.5.2",
-    "fs-extra": "^11.1.1",
     "typescript": "^5.2.2",
     "vite": "^4.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,10 @@ importers:
         version: 18.0.0(react@18.0.0)
 
   libs/qwikdev-astro:
+    dependencies:
+      fs-extra:
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.2.17
@@ -52,9 +56,6 @@ importers:
       astro:
         specifier: ^3.5.2
         version: 3.5.2(@types/node@20.8.9)(typescript@5.2.2)
-      fs-extra:
-        specifier: ^11.1.1
-        version: 11.1.1
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1670,7 +1671,7 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
-    dev: true
+    dev: false
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2024,7 +2025,7 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
+    dev: false
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -3413,7 +3414,7 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-    dev: true
+    dev: false
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}


### PR DESCRIPTION
This adjustment is made to prevent users from manually installing 'fs-extra' when using '@qwikdev/astro'.