### PR TITLE
Fixes #26 - Rollup not resolving path aliases on build.

### DIFF
--- a/apps/astro-demo/src/components/counter.tsx
+++ b/apps/astro-demo/src/components/counter.tsx
@@ -1,13 +1,15 @@
-import { Slot, component$, useSignal } from "@builder.io/qwik";
+import { component$, useSignal } from "@builder.io/qwik";
 
 export const Counter = component$<{ initial: number }>((props) => {
-  const counter = useSignal(0);
+
+  const counter = useSignal(props.initial);
 
   return (
-    <button onClick$={() => counter.value++}>
-      <Slot />
-      <Slot name="test" />
-      {counter.value}
-    </button>
+
+    <>
+      <button onClick$={() => counter.value++}>
+        {counter.value}
+      </button>
+    </>
   );
 });

--- a/apps/astro-demo/src/pages/index.astro
+++ b/apps/astro-demo/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
-import { Counter } from "../components/counter";
-import { ReactCounter } from "../components/react-counter";
+import { Counter } from "@components/counter";
 ---
 
 <html lang="en">
@@ -13,10 +12,8 @@ import { ReactCounter } from "../components/react-counter";
 	</head>
 	<body>
 		<h1>Astro.js - Qwik</h1>
-		<Counter initial={9}>
+		<Counter initial={5}>
 			Some text!
-			<p>test</p>
-			<div slot="test">test</div>
 		</Counter>
 	</body>
 </html>

--- a/apps/astro-demo/tsconfig.json
+++ b/apps/astro-demo/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+
+    "baseUrl": ".",
+    "paths": {
+
+      "@components/*": ["./src/components/*"],
+    },
+
     "jsx": "react-jsx",
     "jsxImportSource": "@builder.io/qwik"
   }

--- a/libs/qwikdev-astro/package.json
+++ b/libs/qwikdev-astro/package.json
@@ -50,7 +50,8 @@
   },
   "bugs": "https://github.com/thejackshelton/@qwikdev/astro/issues",
   "dependencies": {
-    "fs-extra": "^11.1.1"
+    "fs-extra": "^11.1.1",
+    "vite-tsconfig-paths": "^4.2.1"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.2.19",

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,5 +1,6 @@
 import type { AstroConfig, AstroIntegration } from "astro";
 import ts from "typescript";
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 import { build, createFilter, type FilterPattern } from "vite";
 import { qwikVite } from "@builder.io/qwik/optimizer";
@@ -93,6 +94,7 @@ export default function createIntegration(
                     input: "@qwikdev/astro/server",
                   },
                 }),
+                tsconfigPaths()
               ],
             },
           });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
+      vite-tsconfig-paths:
+        specifier: ^4.2.1
+        version: 4.2.1(typescript@5.3.2)(vite@4.5.0)
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.2.19
@@ -1620,6 +1623,10 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+
+  /globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -3206,6 +3213,19 @@ packages:
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
 
+  /tsconfck@2.1.2(typescript@5.3.2):
+    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.3.2
+    dev: false
+
   /tsconfck@3.0.0(typescript@5.3.2):
     resolution: {integrity: sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==}
     engines: {node: ^18 || >=20}
@@ -3397,6 +3417,23 @@ packages:
       '@types/unist': 3.0.0
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
+
+  /vite-tsconfig-paths@4.2.1(typescript@5.3.2)(vite@4.5.0):
+    resolution: {integrity: sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 2.1.2(typescript@5.3.2)
+      vite: 4.5.0(@types/node@20.10.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
 
   /vite@4.5.0(@types/node@20.10.0):
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}


### PR DESCRIPTION
Fixed #26. Turns out Qwik doesn't resolve the `paths` in the `tsconfig.json` out of the box. You need the vite plugin `vite-tsconfig-paths` as done [in the docs](https://qwik.builder.io/docs/advanced/vite/#plugins). The custom `build` step didn't resolve the paths because of the missing plugin.