### PR TITLE
fix: Build fails when outDir (other than the default) does not exist

### DIFF
--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -160,6 +160,9 @@ export default defineIntegration({
           // make sure vite does not parse .astro files
           await build({
             ...astroConfig?.vite,
+            build: {
+              outDir: distDir
+            },
             plugins: [
               ...(astroConfig?.vite.plugins || []),
               {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -83,13 +83,14 @@ export default defineIntegration({
         entrypoints = getQwikEntrypoints(srcDir, filter);
 
         if ((await entrypoints).length !== 0) {
+          // Update the global dist directory
+          distDir = astroConfig.outDir.pathname;
+          await fsExtra.ensureDir(distDir);
+
           addRenderer({
             name: "@qwikdev/astro",
             serverEntrypoint: resolve("../server.ts")
           });
-
-          // Update the global dist directory
-          distDir = astroConfig.outDir.pathname;
 
           // checks all windows platforms and removes drive ex: C:\\
           if (os.platform() === "win32") {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -125,7 +125,8 @@ export default defineIntegration({
                       all of the entry points to the application so
                       that we can generate the manifest. 
                     */
-                    input: await entrypoints
+                    input: await entrypoints,
+                    outDir: 'test'
                   },
                   ssr: {
                     input: resolve("../server.ts")

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -126,7 +126,7 @@ export default defineIntegration({
                       that we can generate the manifest. 
                     */
                     input: await entrypoints,
-                    outDir: 'test'
+                    outDir: "test"
                   },
                   ssr: {
                     input: resolve("../server.ts")

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -130,7 +130,7 @@ export default defineIntegration({
                     outDir: "test"
                   },
                   ssr: {
-                    input: resolve("../server.ts"),
+                    input: resolve("../server.ts")
                   }
                 }),
                 tsconfigPaths(),

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -85,6 +85,7 @@ export default defineIntegration({
         if ((await entrypoints).length !== 0) {
           // Update the global dist directory
           distDir = astroConfig.outDir.pathname;
+          console.log("distDir", distDir);
           await fsExtra.ensureDir(distDir);
 
           addRenderer({
@@ -129,7 +130,7 @@ export default defineIntegration({
                     outDir: "test"
                   },
                   ssr: {
-                    input: resolve("../server.ts")
+                    input: resolve("../server.ts"),
                   }
                 }),
                 tsconfigPaths(),


### PR DESCRIPTION
fixes #74 