### PR TITLE
fix:(cli/templates) biome apply unsafe is deprecated error

### DIFF
--- a/libs/create-qwikdev-astro/stubs/templates/deno-biome/package.json
+++ b/libs/create-qwikdev-astro/stubs/templates/deno-biome/package.json
@@ -13,7 +13,7 @@
     "dev": "astro dev",
     "fix": "npm run lint && npm run format && npm run sync",
     "format": "biome format --write .",
-    "lint": "biome check --apply-unsafe .",
+    "lint": "biome check --write --unsafe .",
     "preview": "npm run build && npm run serve",
     "prod": "npm run build && npm run deploy",
     "serve": "deno run -A --unstable ./dist/server/entry.mjs",

--- a/libs/create-qwikdev-astro/stubs/templates/node-biome/package.json
+++ b/libs/create-qwikdev-astro/stubs/templates/node-biome/package.json
@@ -12,7 +12,7 @@
     "dev": "astro dev",
     "fix": "npm run lint && npm run format",
     "format": "biome format --write .",
-    "lint": "biome check --apply-unsafe .",
+    "lint": "biome check --write --unsafe .",
     "preview": "npm run build && npm run serve",
     "prod": "npm run check && astro build",
     "serve": "node ./dist/server/entry.mjs",

--- a/libs/create-qwikdev-astro/stubs/templates/none-biome/package.json
+++ b/libs/create-qwikdev-astro/stubs/templates/none-biome/package.json
@@ -12,7 +12,7 @@
     "dev": "astro dev",
     "fix": "npm run lint && npm run format",
     "format": "biome format --write .",
-    "lint": "biome check --apply-unsafe .",
+    "lint": "biome check --write --unsafe .",
     "preview": "npm run build && astro preview",
     "prod": "npm run check && astro build",
     "start": "astro dev --open"


### PR DESCRIPTION
Hey All,
Small update:

Getting the below error when running lint command.


![apply unsafe is deprecated](https://github.com/user-attachments/assets/290713e5-8964-4c27-8c8e-a07e3821332c)

Currently no panic on this for a release, but just it will stop working at some point.
Tested the updated command on a Vercel release this morning, worked fine.
![image](https://github.com/user-attachments/assets/43e7bd39-4b22-43ce-89a7-6908cf81018b)