### PR TITLE
fix: vercel static builds failing

### DIFF
--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -6,10 +6,17 @@ import {
   getQwikLoaderScript,
   renderToStream
 } from "@builder.io/qwik/server";
-import type { SSRResult } from "astro";
+import { type SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
-const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="/build/"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
+
+const isSSR = process.env.IS_SSR;
+
+let buildLocation = "/build/";
+if (!isSSR) {
+  buildLocation = "/client/build/";
+}
+const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="${buildLocation}"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
 
 type RendererContext = {
   result: SSRResult;

--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -6,13 +6,10 @@ import {
   getQwikLoaderScript,
   renderToStream
 } from "@builder.io/qwik/server";
-import { type SSRResult } from "astro";
+import type { SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
-
-let buildLocation = "/server/build/";
-
-const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="${buildLocation}"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
+const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="/build/"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
 
 type RendererContext = {
   result: SSRResult;

--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -10,7 +10,7 @@ import { type SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
 
-let buildLocation = "/client/build/";
+let buildLocation = "/server/build/";
 
 const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="${buildLocation}"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
 

--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -10,12 +10,12 @@ import { type SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
 
-const isSSR = Boolean(process.env.IS_SSR);
-
 let buildLocation = "/build/";
-if (!isSSR) {
+
+if (globalThis.setBuildLocation) {
   buildLocation = "/client/build/";
 }
+
 const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="${buildLocation}"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
 
 type RendererContext = {

--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -10,7 +10,7 @@ import { type SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
 
-const isSSR = process.env.IS_SSR;
+const isSSR = Boolean(process.env.IS_SSR);
 
 let buildLocation = "/build/";
 if (!isSSR) {

--- a/libs/qwikdev-astro/server.ts
+++ b/libs/qwikdev-astro/server.ts
@@ -10,11 +10,7 @@ import { type SSRResult } from "astro";
 
 const isQwikLoaderAddedMap = new WeakMap<SSRResult, boolean>();
 
-let buildLocation = "/build/";
-
-if (globalThis.setBuildLocation) {
-  buildLocation = "/client/build/";
-}
+let buildLocation = "/client/build/";
 
 const modulePreloadScript = `window.addEventListener("load",()=>{(async()=>{window.requestIdleCallback||(window.requestIdleCallback=(e,t)=>{const n=t||{},o=1,i=n.timeout||o,a=performance.now();return setTimeout(()=>{e({get didTimeout(){return!n.timeout&&performance.now()-a-o>i},timeRemaining:()=>Math.max(0,o+(performance.now()-a))})},o)});const e=async()=>{const e=new Set,t=document.querySelectorAll('script[q\\\\:type="prefetch-bundles"]');t.forEach(t=>{if(!t.textContent)return;const n=t.textContent,o=n.match(/\\["prefetch","[/]build[/]","(.*?)"\\]/);o&&o[1]&&o[1].split('","').forEach(t=>{t.startsWith("q-")&&e.add(t)})}),document.querySelectorAll('script[type="qwik/json"]').forEach(t=>{if(!t.textContent)return;const n=t.textContent.match(/q-[A-Za-z0-9_-]+\\.js/g);n&&n.forEach(t=>e.add(t))}),e.forEach(e=>{const t=document.createElement("link");t.rel="modulepreload",t.href="${buildLocation}"+e,t.fetchPriority="low",document.head.appendChild(t)})};await requestIdleCallback(await e)})()});`;
 

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-
 import { join } from "node:path";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {
@@ -108,13 +107,6 @@ export default defineIntegration({
           finalDir = clientDir;
         } else {
           finalDir = outDir;
-        }
-
-        if (
-          astroConfig.adapter?.name.includes("vercel") &&
-          finalDir.includes("/client/")
-        ) {
-          finalDir = finalDir.replace("/client/", "/");
         }
 
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
@@ -252,9 +244,6 @@ export default defineIntegration({
 
               if (astroConfig?.adapter) {
                 const serverChunksDir = join(serverDir, "chunks");
-                if (!fs.existsSync(serverChunksDir)) {
-                  fs.mkdirSync(serverChunksDir, { recursive: true });
-                }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(
                   (f) => f.startsWith("server_") && f.endsWith(".mjs")

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -104,7 +104,11 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
-        finalDir = outDir;
+        if (astroConfig.adapter) {
+          finalDir = clientDir;
+        } else {
+          finalDir = outDir;
+        }
 
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
@@ -220,6 +224,14 @@ export default defineIntegration({
 
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
+      },
+      "astro:build:generated"(options) {
+        if (
+          astroConfig?.adapter?.name.includes("vercel") &&
+          fs.existsSync("dist/client/build")
+        ) {
+          copyFolderSync("dist/client/build", "dist/build");
+        }
       },
 
       "astro:build:ssr": async () => {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -103,7 +103,7 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
-        if (astroConfig.adapter) {
+        if (astroConfig.adapter && !astroConfig.adapter.name.includes("vercel")) {
           finalDir = clientDir;
         } else {
           finalDir = outDir;
@@ -241,15 +241,9 @@ export default defineIntegration({
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
               if (astroConfig?.adapter) {
-                // depending on the adapter, the chunks folder might be in dist/server/ or dist/
-                let serverChunksDir = join(serverDir, "chunks");
+                const serverChunksDir = join(serverDir, "chunks");
                 if (!fs.existsSync(serverChunksDir)) {
-                  serverChunksDir = join(outDir, "chunks");
-                  if (!fs.existsSync(serverChunksDir)) {
-                    throw new Error(
-                      `Could not find server chunks directory at ${serverChunksDir}`
-                    );
-                  }
+                  fs.mkdirSync(serverChunksDir);
                 }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,7 +1,4 @@
 import fs from "node:fs";
-import { resolve } from "node:path";
-import { pathToFileURL } from "node:url"; // Import pathToFileURL
-
 import { join } from "node:path";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -241,29 +241,28 @@ export default defineIntegration({
             outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
-              setTimeout(() => {
-                if (astroConfig?.adapter) {
-                  const serverChunksDir = join(serverDir, "chunks");
-                  const files = fs.readdirSync(serverChunksDir);
-                  const serverFile = files.find(
-                    (f) => f.startsWith("server_") && f.endsWith(".mjs")
+
+              if (astroConfig?.adapter) {
+                const serverChunksDir = join(serverDir, "chunks");
+                const files = fs.readdirSync(serverChunksDir);
+                const serverFile = files.find(
+                  (f) => f.startsWith("server_") && f.endsWith(".mjs")
+                );
+
+                if (serverFile) {
+                  const serverPath = join(serverChunksDir, serverFile);
+                  const content = fs.readFileSync(serverPath, "utf-8");
+
+                  // Replace the manifest handling in the bundled code
+                  const manifestJson = JSON.stringify(manifest);
+                  const newContent = content.replace(
+                    "globalThis.qManifest",
+                    `globalThis.qManifest || ${manifestJson}`
                   );
 
-                  if (serverFile) {
-                    const serverPath = join(serverChunksDir, serverFile);
-                    const content = fs.readFileSync(serverPath, "utf-8");
-
-                    // Replace the manifest handling in the bundled code
-                    const manifestJson = JSON.stringify(manifest);
-                    const newContent = content.replace(
-                      "globalThis.qManifest",
-                      `globalThis.qManifest || ${manifestJson}`
-                    );
-
-                    fs.writeFileSync(serverPath, newContent);
-                  }
+                  fs.writeFileSync(serverPath, newContent);
                 }
-              }, 0);
+              }
             }
           },
           debug: options?.debug ?? false

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -134,9 +134,10 @@ export default defineIntegration({
             resolveEntrypoints();
           },
           async resolveId(id, importer) {
-            const isFromAstro = importer?.endsWith('.astro') || importer?.endsWith('.mdx');
-            const isFromTrackedFile = potentialEntries.has(importer ?? '');
-            
+            const isFromAstro =
+              importer?.endsWith(".astro") || importer?.endsWith(".mdx");
+            const isFromTrackedFile = potentialEntries.has(importer ?? "");
+
             if (!isFromAstro && !isFromTrackedFile) {
               return null;
             }
@@ -240,9 +241,17 @@ export default defineIntegration({
             outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
-
               if (astroConfig?.adapter) {
-                const serverChunksDir = join(serverDir, "chunks");
+                // depending on the adapter, the chunks folder might be in dist/server/ or dist/
+                let serverChunksDir = join(serverDir, "chunks");
+                if (!fs.existsSync(serverChunksDir)) {
+                  serverChunksDir = join(outDir, "chunks");
+                  if (!fs.existsSync(serverChunksDir)) {
+                    throw new Error(
+                      `Could not find server chunks directory at ${serverChunksDir}`
+                    );
+                  }
+                }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(
                   (f) => f.startsWith("server_") && f.endsWith(".mjs")

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -202,9 +202,6 @@ export default defineIntegration({
         };
 
         updateConfig({
-          build: {
-            client: new URL("./", astroConfig.root)
-          },
           vite: {
             build: {
               rollupOptions: {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -263,7 +263,7 @@ export default defineIntegration({
                     fs.writeFileSync(serverPath, newContent);
                   }
                 }
-              }, 1000);
+              }, 0);
             }
           },
           debug: options?.debug ?? false

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -336,7 +336,7 @@ export default defineIntegration({
             if (!fs.existsSync(path.join(outDir, "build", qwikFile))) {
               validBuild = false;
               throw new Error(
-                `Qwik file ${qwikFile} not found in ${path.join(finalDir, "build")}`
+                `Qwik file ${qwikFile} not found in ${path.join(outDir, "build")}`
               );
             }
           }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -314,7 +314,20 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-
+      "astro:build:generated"({ logger }) {
+        const locationString = path.join(outDir, "build");
+        if (fs.existsSync(path.join(outDir, "build"))) {
+          logger.info(
+            `Static files already exist in ${locationString} directory - skipping move`
+          );
+          return;
+        }
+        const srcPath = path.join(clientDir, "build");
+        const destPath = path.join(outDir, "build");
+        logger.info(`Copying static files from ${srcPath} to ${destPath}`);
+        copyFolderSync(srcPath, destPath);
+        logger.info(`Static files copied to ${locationString} directory`);
+      },
       "astro:build:done"({ logger }) {
         let errorMessage = "";
         logger.info(

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -189,7 +189,7 @@ export default defineIntegration({
           },
           client: {
             input: resolver("./root.tsx"),
-            outDir: outDir
+            outDir: finalDir
           },
           debug: options?.debug ?? false
         };
@@ -242,31 +242,30 @@ export default defineIntegration({
             outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
+              setTimeout(() => {
+                if (astroConfig?.adapter) {
+                  const serverChunksDir = join(serverDir, "chunks");
 
-              if (astroConfig?.adapter) {
-                const serverChunksDir = join(serverDir, "chunks");
-                if (!fs.existsSync(serverChunksDir)) {
-                  fs.mkdirSync(serverChunksDir, { recursive: true });
-                }
-                const files = fs.readdirSync(serverChunksDir);
-                const serverFile = files.find(
-                  (f) => f.startsWith("server_") && f.endsWith(".mjs")
-                );
-
-                if (serverFile) {
-                  const serverPath = join(serverChunksDir, serverFile);
-                  const content = fs.readFileSync(serverPath, "utf-8");
-
-                  // Replace the manifest handling in the bundled code
-                  const manifestJson = JSON.stringify(manifest);
-                  const newContent = content.replace(
-                    "globalThis.qManifest",
-                    `globalThis.qManifest || ${manifestJson}`
+                  const files = fs.readdirSync(serverChunksDir);
+                  const serverFile = files.find(
+                    (f) => f.startsWith("server_") && f.endsWith(".mjs")
                   );
 
-                  fs.writeFileSync(serverPath, newContent);
+                  if (serverFile) {
+                    const serverPath = join(serverChunksDir, serverFile);
+                    const content = fs.readFileSync(serverPath, "utf-8");
+
+                    // Replace the manifest handling in the bundled code
+                    const manifestJson = JSON.stringify(manifest);
+                    const newContent = content.replace(
+                      "globalThis.qManifest",
+                      `globalThis.qManifest || ${manifestJson}`
+                    );
+
+                    fs.writeFileSync(serverPath, newContent);
+                  }
                 }
-              }
+              }, 1000);
             }
           },
           debug: options?.debug ?? false

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -107,7 +107,7 @@ export default defineIntegration({
           astroConfig.output === "static" &&
           astroConfig.adapter?.name === "@astrojs/vercel"
         ) {
-          process.env.IS_SSR = "false";
+          globalThis.setBuildLocation = true;
         }
         if (astroConfig.adapter) {
           finalDir = clientDir;

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -10,6 +10,7 @@ import type {
 import type { AstroConfig, AstroIntegration } from "astro";
 import { createResolver, defineIntegration, watchDirectory } from "astro-integration-kit";
 import { z } from "astro/zod";
+import { Logger } from "node_modules/astro/dist/core/logger/core";
 import { type PluginOption, build, createFilter } from "vite";
 import type { InlineConfig } from "vite";
 
@@ -314,9 +315,9 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-      "astro:build:generated"() {
+      "astro:build:generated"({ logger }) {
         if (fs.existsSync(path.join(outDir, "build"))) {
-          //  if build folder is already there, we don't need to copy
+          logger.info("Build folder already exists, skipping copy");
           return;
         }
         if (!fs.existsSync(path.join(outDir, "build"))) {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -103,6 +103,12 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
+        if (
+          astroConfig.output === "static" &&
+          astroConfig.adapter?.name === "@astrojs/vercel"
+        ) {
+          process.env.IS_SSR = "false";
+        }
         if (astroConfig.adapter) {
           finalDir = clientDir;
         } else {
@@ -159,7 +165,6 @@ export default defineIntegration({
             if (!potentialEntries.has(id)) {
               return null;
             }
-
             /**
              *  Qwik Entrypoints
              *  ---

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -103,7 +103,7 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
-        if (astroConfig.adapter && !astroConfig.adapter.name.includes("vercel")) {
+        if (astroConfig.adapter) {
           finalDir = clientDir;
         } else {
           finalDir = outDir;
@@ -159,6 +159,7 @@ export default defineIntegration({
             if (!potentialEntries.has(id)) {
               return null;
             }
+
             /**
              *  Qwik Entrypoints
              *  ---
@@ -240,10 +241,11 @@ export default defineIntegration({
             outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
+
               if (astroConfig?.adapter) {
-                const serverChunksDir = join(finalDir, "chunks");
+                const serverChunksDir = join(serverDir, "chunks");
                 if (!fs.existsSync(serverChunksDir)) {
-                  fs.mkdirSync(serverChunksDir);
+                  fs.mkdirSync(serverChunksDir, { recursive: true });
                 }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -9,7 +9,6 @@ import type {
 import type { AstroConfig, AstroIntegration } from "astro";
 import { createResolver, defineIntegration, watchDirectory } from "astro-integration-kit";
 import { z } from "astro/zod";
-import type { c } from "node_modules/vite/dist/node/types.d-aGj9QkWt";
 import { type PluginOption, build, createFilter } from "vite";
 import type { InlineConfig } from "vite";
 
@@ -81,8 +80,8 @@ export default defineIntegration({
       "astro:config:setup": async (setupProps) => {
         const { addRenderer, updateConfig, config, createCodegenDir } = setupProps;
         astroConfig = config;
-        createCodegenDir();
-
+        const location = createCodegenDir();
+        console.log("Astro codegen location", location);
         // integration HMR support
         watchDirectory(setupProps, resolver());
 

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { join } from "node:path";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {
@@ -224,6 +225,14 @@ export default defineIntegration({
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
       },
+      "astro:build:generated"(options) {
+        if (
+          astroConfig?.adapter?.name.includes("vercel") &&
+          fs.existsSync("dist/client/build")
+        ) {
+          copyFolderSync("dist/client/build", "dist/build");
+        }
+      },
 
       "astro:build:ssr": async () => {
         await entrypointsReady;
@@ -322,4 +331,23 @@ export default defineIntegration({
 
 function getRelativePath(from: string, to: string) {
   return to.replace(from, "") || ".";
+}
+
+function copyFolderSync(src: string, dest: string) {
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest, { recursive: true });
+  }
+
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyFolderSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { join } from "node:path";
-import { object } from "astro:schema";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {
   QwikManifest,

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -315,20 +315,7 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-      // "astro:build:generated"({ logger }) {
-      //   const locationString = path.join(outDir, "build");
-      //   if (fs.existsSync(path.join(outDir, "build"))) {
-      //     logger.info(
-      //       `Static files already exist in ${locationString} directory - skipping move`
-      //     );
-      //     return;
-      //   }
-      //   const srcPath = path.join(clientDir, "build");
-      //   const destPath = path.join(outDir, "build");
-      //   logger.info(`Copying static files from ${srcPath} to ${destPath}`);
-      //   copyFolderSync(srcPath, destPath);
-      //   logger.info(`Static files copied to ${locationString} directory`);
-      // },
+
       "astro:build:done"({ logger }) {
         let errorMessage = "";
         logger.info(

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -107,6 +107,12 @@ export default defineIntegration({
           finalDir = outDir;
         }
 
+        if (finalDir !== outDir) {
+          const outDirUrl = new URL(astroConfig.outDir.pathname, astroConfig.root);
+          astroConfig.build.client = outDirUrl;
+          finalDir = astroConfig.build.client.pathname;
+        }
+
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
           if (hook === "transform") {
@@ -223,7 +229,7 @@ export default defineIntegration({
         astroVite = vite as InlineConfig;
       },
 
-      "astro:build:ssr": async () => {
+      "astro:build:ssr": async (manifest) => {
         await entrypointsReady;
 
         // Astro's SSR build finished -> Now we can handle how Qwik normally builds

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -92,10 +92,7 @@ export default defineIntegration({
         /** Relative paths, as the Qwik optimizer handles normalization */
         srcDir = getRelativePath(astroConfig.root.pathname, astroConfig.srcDir.pathname);
 
-        clientDir = getRelativePath(
-          astroConfig.root.pathname,
-          astroConfig.build.client.pathname
-        );
+        clientDir = getRelativePath(astroConfig.root.pathname, "dist/");
 
         serverDir = getRelativePath(
           astroConfig.root.pathname,
@@ -225,14 +222,6 @@ export default defineIntegration({
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
       },
-      "astro:build:generated"(options) {
-        if (
-          astroConfig?.adapter?.name.includes("vercel") &&
-          fs.existsSync("dist/client/build")
-        ) {
-          copyFolderSync("dist/client/build", "dist/build");
-        }
-      },
 
       "astro:build:ssr": async () => {
         await entrypointsReady;
@@ -331,23 +320,4 @@ export default defineIntegration({
 
 function getRelativePath(from: string, to: string) {
   return to.replace(from, "") || ".";
-}
-
-function copyFolderSync(src: string, dest: string) {
-  if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest, { recursive: true });
-  }
-
-  const entries = fs.readdirSync(src, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-
-    if (entry.isDirectory()) {
-      copyFolderSync(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
-  }
 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -110,6 +110,8 @@ export default defineIntegration({
           finalDir = outDir;
         }
 
+        finalDir = finalDir.replace("/client", "");
+
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
           if (hook === "transform") {
@@ -225,14 +227,14 @@ export default defineIntegration({
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
       },
-      "astro:build:generated"(options) {
-        if (
-          astroConfig?.adapter?.name.includes("vercel") &&
-          fs.existsSync("dist/client/build")
-        ) {
-          copyFolderSync("dist/client/build", "dist/build");
-        }
-      },
+      // "astro:build:generated"(options) {
+      //   if (
+      //     astroConfig?.adapter?.name.includes("vercel") &&
+      //     fs.existsSync("dist/client/build")
+      //   ) {
+      //     copyFolderSync("dist/client/build", "dist/build");
+      //   }
+      // },
 
       "astro:build:ssr": async () => {
         await entrypointsReady;

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -189,7 +189,7 @@ export default defineIntegration({
           },
           client: {
             input: resolver("./root.tsx"),
-            outDir: finalDir
+            outDir: outDir
           },
           debug: options?.debug ?? false
         };
@@ -224,14 +224,6 @@ export default defineIntegration({
 
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
-      },
-      "astro:build:generated"(options) {
-        if (
-          astroConfig?.adapter?.name.includes("vercel") &&
-          fs.existsSync("dist/client/build")
-        ) {
-          copyFolderSync("dist/client/build", "dist/build");
-        }
       },
 
       "astro:build:ssr": async () => {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -110,8 +110,6 @@ export default defineIntegration({
           finalDir = outDir;
         }
 
-        finalDir = finalDir.replace("/client", "");
-
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
           if (hook === "transform") {
@@ -227,14 +225,14 @@ export default defineIntegration({
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
       },
-      // "astro:build:generated"(options) {
-      //   if (
-      //     astroConfig?.adapter?.name.includes("vercel") &&
-      //     fs.existsSync("dist/client/build")
-      //   ) {
-      //     copyFolderSync("dist/client/build", "dist/build");
-      //   }
-      // },
+      "astro:build:generated"(options) {
+        if (
+          astroConfig?.adapter?.name.includes("vercel") &&
+          fs.existsSync("dist/client/build")
+        ) {
+          copyFolderSync("dist/client/build", "dist/build");
+        }
+      },
 
       "astro:build:ssr": async () => {
         await entrypointsReady;

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import path from "node:path";
+
 import { join } from "node:path";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {
@@ -330,23 +330,4 @@ export default defineIntegration({
 
 function getRelativePath(from: string, to: string) {
   return to.replace(from, "") || ".";
-}
-
-function copyFolderSync(src: string, dest: string) {
-  if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest, { recursive: true });
-  }
-
-  const entries = fs.readdirSync(src, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-
-    if (entry.isDirectory()) {
-      copyFolderSync(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
-  }
 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { join } from "node:path";
 import { qwikVite, symbolMapper } from "@builder.io/qwik/optimizer";
 import type {
@@ -224,6 +225,14 @@ export default defineIntegration({
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
       },
+      "astro:build:generated"(options) {
+        if (
+          astroConfig?.adapter?.name.includes("vercel") &&
+          fs.existsSync("dist/client/build")
+        ) {
+          copyFolderSync("dist/client/build", "dist/build");
+        }
+      },
 
       "astro:build:ssr": async () => {
         await entrypointsReady;
@@ -244,6 +253,9 @@ export default defineIntegration({
 
               if (astroConfig?.adapter) {
                 const serverChunksDir = join(serverDir, "chunks");
+                if (!fs.existsSync(serverChunksDir)) {
+                  fs.mkdirSync(serverChunksDir, { recursive: true });
+                }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(
                   (f) => f.startsWith("server_") && f.endsWith(".mjs")
@@ -319,4 +331,23 @@ export default defineIntegration({
 
 function getRelativePath(from: string, to: string) {
   return to.replace(from, "") || ".";
+}
+
+function copyFolderSync(src: string, dest: string) {
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest, { recursive: true });
+  }
+
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyFolderSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -343,8 +343,7 @@ export default defineIntegration({
         }
         if (!fs.existsSync(path.join(finalDir, "q-manifest.json"))) {
           errorMessage = `Manifest file not found in ${path.join(
-            outDir,
-            "build",
+            finalDir,
             "qwik-manifest.json"
           )}`;
           logger.error(errorMessage);
@@ -356,13 +355,10 @@ export default defineIntegration({
         if (manifestJson) {
           const manifestKeys = Object.keys(manifestJson.bundles);
           if (manifestKeys.length) {
-            logger.info(`Manifest file found in ${path.join(outDir, "build")}`);
+            logger.info(`Manifest file found in ${manifestPath}`);
             for (const key of manifestKeys) {
               if (!fs.existsSync(path.join(outDir, "build", key))) {
-                errorMessage = `Manifest file ${key} not found in ${path.join(
-                  outDir,
-                  "build"
-                )} directory`;
+                errorMessage = `Manifest file ${key} not found in ${manifestPath} directory`;
                 logger.error(errorMessage);
                 throw new Error(errorMessage);
               }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -315,20 +315,20 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-      "astro:build:generated"({ logger }) {
-        const locationString = path.join(outDir, "build");
-        if (fs.existsSync(path.join(outDir, "build"))) {
-          logger.info(
-            `Static files already exist in ${locationString} directory - skipping move`
-          );
-          return;
-        }
-        const srcPath = path.join(clientDir, "build");
-        const destPath = path.join(outDir, "build");
-        logger.info(`Copying static files from ${srcPath} to ${destPath}`);
-        copyFolderSync(srcPath, destPath);
-        logger.info(`Static files copied to ${locationString} directory`);
-      },
+      // "astro:build:generated"({ logger }) {
+      //   const locationString = path.join(outDir, "build");
+      //   if (fs.existsSync(path.join(outDir, "build"))) {
+      //     logger.info(
+      //       `Static files already exist in ${locationString} directory - skipping move`
+      //     );
+      //     return;
+      //   }
+      //   const srcPath = path.join(clientDir, "build");
+      //   const destPath = path.join(outDir, "build");
+      //   logger.info(`Copying static files from ${srcPath} to ${destPath}`);
+      //   copyFolderSync(srcPath, destPath);
+      //   logger.info(`Static files copied to ${locationString} directory`);
+      // },
       "astro:build:done"({ logger }) {
         let errorMessage = "";
         logger.info(

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -104,11 +104,7 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
-        if (astroConfig.adapter) {
-          finalDir = clientDir;
-        } else {
-          finalDir = outDir;
-        }
+        finalDir = outDir;
 
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
@@ -224,14 +220,6 @@ export default defineIntegration({
 
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
-      },
-      "astro:build:generated"(options) {
-        if (
-          astroConfig?.adapter?.name.includes("vercel") &&
-          fs.existsSync("dist/client/build")
-        ) {
-          copyFolderSync("dist/client/build", "dist/build");
-        }
       },
 
       "astro:build:ssr": async () => {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -110,6 +110,13 @@ export default defineIntegration({
           finalDir = outDir;
         }
 
+        if (
+          astroConfig.adapter?.name.includes("vercel") &&
+          finalDir.includes("/client/")
+        ) {
+          finalDir = finalDir.replace("/client/", "/");
+        }
+
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
         const fileFilter = (id: string, hook: string) => {
           if (hook === "transform") {
@@ -224,14 +231,6 @@ export default defineIntegration({
 
       "astro:build:setup": async ({ vite }) => {
         astroVite = vite as InlineConfig;
-      },
-      "astro:build:generated"(options) {
-        if (
-          astroConfig?.adapter?.name.includes("vercel") &&
-          fs.existsSync("dist/client/build")
-        ) {
-          copyFolderSync("dist/client/build", "dist/build");
-        }
       },
 
       "astro:build:ssr": async () => {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -315,34 +315,10 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-      "astro:build:generated"({ logger }) {
-        if (fs.existsSync(path.join(outDir, "build"))) {
-          logger.info("Build folder already exists, skipping copy");
-          return;
-        }
+      "astro:build:generated"() {
         if (!fs.existsSync(path.join(outDir, "build"))) {
           if (fs.existsSync(path.join(clientDir, "build"))) {
             copyFolderSync(path.join(clientDir, "build"), path.join(outDir, "build"));
-          }
-        }
-      },
-      "astro:build:done"({ logger }) {
-        if (fs.existsSync(path.join(finalDir, "q-manifest.json"))) {
-          const qManifestContents = JSON.parse(
-            fs.readFileSync(path.join(finalDir, "q-manifest.json"), "utf-8")
-          );
-          const qwikFiles = Object.keys(qManifestContents.bundles);
-          let validBuild = true;
-          for (const qwikFile of qwikFiles) {
-            if (!fs.existsSync(path.join(outDir, "build", qwikFile))) {
-              validBuild = false;
-              throw new Error(
-                `Qwik file ${qwikFile} not found in ${path.join(outDir, "build")}`
-              );
-            }
-          }
-          if (validBuild) {
-            logger.info("Build Successful!");
           }
         }
       }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -103,12 +103,6 @@ export default defineIntegration({
 
         outDir = getRelativePath(astroConfig.root.pathname, astroConfig.outDir.pathname);
 
-        if (
-          astroConfig.output === "static" &&
-          astroConfig.adapter?.name === "@astrojs/vercel"
-        ) {
-          globalThis.setBuildLocation = true;
-        }
         if (astroConfig.adapter) {
           finalDir = clientDir;
         } else {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -396,6 +396,9 @@ function copyFolderSync(src: string, dest: string) {
       copyFolderSync(srcPath, destPath);
     } else {
       try {
+        if (fs.existsSync(destPath)) {
+          fs.rmSync(destPath);
+        }
         fs.copyFileSync(srcPath, destPath);
       } catch (error) {
         throw new Error(`Failed to copy file from ${srcPath} to ${destPath}: ${error}`);

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -103,14 +103,13 @@ export default defineIntegration({
 
         if (astroConfig.adapter) {
           finalDir = clientDir;
+          if (astroConfig.adapter?.name.includes("vercel")) {
+            const outDirUrl = new URL(astroConfig.outDir.pathname, astroConfig.root);
+            astroConfig.build.client = outDirUrl;
+            finalDir = astroConfig.build.client.pathname;
+          }
         } else {
           finalDir = outDir;
-        }
-
-        if (finalDir !== outDir) {
-          const outDirUrl = new URL(astroConfig.outDir.pathname, astroConfig.root);
-          astroConfig.build.client = outDirUrl;
-          finalDir = astroConfig.build.client.pathname;
         }
 
         /** check if the file should be processed based on the 'transform' hook and user-defined filters (include & exclude) */
@@ -229,7 +228,7 @@ export default defineIntegration({
         astroVite = vite as InlineConfig;
       },
 
-      "astro:build:ssr": async (manifest) => {
+      "astro:build:ssr": async () => {
         await entrypointsReady;
 
         // Astro's SSR build finished -> Now we can handle how Qwik normally builds

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -241,28 +241,29 @@ export default defineIntegration({
             outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
-
-              if (astroConfig?.adapter) {
-                const serverChunksDir = join(serverDir, "chunks");
-                const files = fs.readdirSync(serverChunksDir);
-                const serverFile = files.find(
-                  (f) => f.startsWith("server_") && f.endsWith(".mjs")
-                );
-
-                if (serverFile) {
-                  const serverPath = join(serverChunksDir, serverFile);
-                  const content = fs.readFileSync(serverPath, "utf-8");
-
-                  // Replace the manifest handling in the bundled code
-                  const manifestJson = JSON.stringify(manifest);
-                  const newContent = content.replace(
-                    "globalThis.qManifest",
-                    `globalThis.qManifest || ${manifestJson}`
+              setTimeout(() => {
+                if (astroConfig?.adapter) {
+                  const serverChunksDir = join(serverDir, "chunks");
+                  const files = fs.readdirSync(serverChunksDir);
+                  const serverFile = files.find(
+                    (f) => f.startsWith("server_") && f.endsWith(".mjs")
                   );
 
-                  fs.writeFileSync(serverPath, newContent);
+                  if (serverFile) {
+                    const serverPath = join(serverChunksDir, serverFile);
+                    const content = fs.readFileSync(serverPath, "utf-8");
+
+                    // Replace the manifest handling in the bundled code
+                    const manifestJson = JSON.stringify(manifest);
+                    const newContent = content.replace(
+                      "globalThis.qManifest",
+                      `globalThis.qManifest || ${manifestJson}`
+                    );
+
+                    fs.writeFileSync(serverPath, newContent);
+                  }
                 }
-              }
+              }, 1000);
             }
           },
           debug: options?.debug ?? false

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -10,7 +10,6 @@ import type {
 import type { AstroConfig, AstroIntegration } from "astro";
 import { createResolver, defineIntegration, watchDirectory } from "astro-integration-kit";
 import { z } from "astro/zod";
-import { Logger } from "node_modules/astro/dist/core/logger/core";
 import { type PluginOption, build, createFilter } from "vite";
 import type { InlineConfig } from "vite";
 
@@ -319,6 +318,7 @@ export default defineIntegration({
         if (!fs.existsSync(path.join(outDir, "build"))) {
           if (fs.existsSync(path.join(clientDir, "build"))) {
             copyFolderSync(path.join(clientDir, "build"), path.join(outDir, "build"));
+            return;
           }
         }
       }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -237,11 +237,11 @@ export default defineIntegration({
           },
           client: {
             input: [...qwikEntrypoints, resolver("./root.tsx")],
-            outDir: serverDir,
+            outDir: finalDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
               if (astroConfig?.adapter) {
-                const serverChunksDir = join(serverDir, "chunks");
+                const serverChunksDir = join(finalDir, "chunks");
                 if (!fs.existsSync(serverChunksDir)) {
                   fs.mkdirSync(serverChunksDir);
                 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -372,9 +372,6 @@ function copyFolderSync(src: string, dest: string) {
       copyFolderSync(srcPath, destPath);
     } else {
       fs.copyFileSync(srcPath, destPath);
-      if (fs.existsSync(srcPath) && fs.existsSync(destPath)) {
-        fs.unlinkSync(srcPath);
-      }
     }
   }
 }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -238,7 +238,7 @@ export default defineIntegration({
           },
           client: {
             input: [...qwikEntrypoints, resolver("./root.tsx")],
-            outDir: finalDir,
+            outDir: clientDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
               if (astroConfig?.adapter) {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -325,20 +325,27 @@ export default defineIntegration({
         if (!fs.existsSync(path.join(outDir, "build"))) {
           if (fs.existsSync(path.join(clientDir, "build"))) {
             logger.info(`Moving static files to ${locationString} directory`);
-            moveStaticFiles(
-              path.join(clientDir, "build"),
-              path.join(outDir, "build"),
-              (err: any) => {
-                if (!err) {
-                  const successMessage = `Static files moved to ${locationString} directory`;
-                  logger.info(successMessage);
-                  return;
-                }
-                const errorMessage = `Error moving static files: ${err}`;
-                logger.error(errorMessage);
-                throw new Error(errorMessage);
+            const files = fs.readdirSync(path.join(clientDir, "build"));
+            for (const file of files) {
+              if (!file.startsWith("q-")) {
+                continue;
               }
-            );
+              const oldPath = path.join(clientDir, "build", file);
+              const newPath = path.join(outDir, "build", file);
+              if (fs.existsSync(oldPath)) {
+                if (!fs.existsSync(path.join(outDir, "build"))) {
+                  fs.mkdirSync(path.join(outDir, "build"), { recursive: true });
+                }
+                moveStaticFiles(oldPath, newPath, (err: any) => {
+                  if (!err) {
+                    return;
+                  }
+                  const errorMessage = `Error moving static files: ${err}`;
+                  logger.error(errorMessage);
+                  throw new Error(errorMessage);
+                });
+              }
+            }
           }
         }
       }

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -238,7 +238,7 @@ export default defineIntegration({
           },
           client: {
             input: [...qwikEntrypoints, resolver("./root.tsx")],
-            outDir: clientDir,
+            outDir: serverDir,
             manifestOutput: (manifest) => {
               globalThis.qManifest = manifest;
               if (astroConfig?.adapter) {

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -314,21 +314,21 @@ export default defineIntegration({
           }
         } as InlineConfig);
       },
-      "astro:build:generated"({ logger }) {
-        const locationString = path.join(outDir, "build");
+
+      "astro:build:done"({ logger }) {
+        const locationString = fs.existsSync(path.join(outDir, "build"));
         if (fs.existsSync(path.join(outDir, "build"))) {
           logger.info(
             `Static files already exist in ${locationString} directory - skipping move`
           );
-          return;
         }
-        const srcPath = path.join(clientDir, "build");
-        const destPath = path.join(outDir, "build");
-        logger.info(`Copying static files from ${srcPath} to ${destPath}`);
-        copyFolderSync(srcPath, destPath);
-        logger.info(`Static files copied to ${locationString} directory`);
-      },
-      "astro:build:done"({ logger }) {
+        if (!locationString) {
+          const srcPath = path.join(clientDir, "build");
+          const destPath = path.join(outDir, "build");
+          logger.info(`Copying static files from ${srcPath} to ${destPath}`);
+          copyFolderSync(srcPath, destPath);
+          logger.info(`Static files copied to ${locationString} directory`);
+        }
         let errorMessage = "";
         logger.info(
           `Qwik build finished. Check ${path.join(outDir, "build")} for static files`


### PR DESCRIPTION
fixes: #237 


Hey all,
This is a draft PR for now - fix works for local builds, but want to check in production.

I'll update the status after testing in production.

# Description:

For Vercel static builds the chunks folder does not end up in dist/server/ but it is dist/



 ![image confirming the above statement](https://github.com/user-attachments/assets/c5716091-60e4-47bb-aac4-c47f74f213a9)

Added error handling for failure to find the folder.


Open to adding a recursive search for the chunks folder as it's a static build it wouldn't impact server side rendering performance, and future proofs this a bit better. 


## todo:
Production tests to perform

- [ ] static build works in Vercel
- [ ] hybrid build works in Vercel

I want to double check that this hasn't impacted any currently working adopters.
- [ ] static build works in Netlify
- [ ] hybrid build works in Netlify