### PR TITLE
Fix: (integration) improve Vercel Adapter compatibility issues

### DIFF
--- a/.changeset/cyan-bikes-push.md
+++ b/.changeset/cyan-bikes-push.md
@@ -1,0 +1,6 @@
+---
+"@qwikdev/astro": patch
+---
+
+- Fix Vercel builds failing force create serverchunks directory if needed
+- Fix Vercel Adapter Client Static Files Handling

--- a/libs/qwikdev-astro/src/index.ts
+++ b/libs/qwikdev-astro/src/index.ts
@@ -79,10 +79,8 @@ export default defineIntegration({
       "astro:config:setup": async (setupProps) => {
         const { addRenderer, updateConfig, config } = setupProps;
         astroConfig = config;
-
         // integration HMR support
         watchDirectory(setupProps, resolver());
-
         addRenderer({
           name: "@qwikdev/astro",
           serverEntrypoint: resolver("../server.ts")
@@ -105,6 +103,11 @@ export default defineIntegration({
 
         if (astroConfig.adapter) {
           finalDir = clientDir;
+          if (astroConfig.adapter?.name.includes("vercel")) {
+            const outDirUrl = new URL(astroConfig.outDir.pathname, astroConfig.root);
+            astroConfig.build.client = outDirUrl;
+            finalDir = astroConfig.build.client.pathname;
+          }
         } else {
           finalDir = outDir;
         }
@@ -134,9 +137,10 @@ export default defineIntegration({
             resolveEntrypoints();
           },
           async resolveId(id, importer) {
-            const isFromAstro = importer?.endsWith('.astro') || importer?.endsWith('.mdx');
-            const isFromTrackedFile = potentialEntries.has(importer ?? '');
-            
+            const isFromAstro =
+              importer?.endsWith(".astro") || importer?.endsWith(".mdx");
+            const isFromTrackedFile = potentialEntries.has(importer ?? "");
+
             if (!isFromAstro && !isFromTrackedFile) {
               return null;
             }
@@ -243,6 +247,9 @@ export default defineIntegration({
 
               if (astroConfig?.adapter) {
                 const serverChunksDir = join(serverDir, "chunks");
+                if (!fs.existsSync(serverChunksDir)) {
+                  fs.mkdirSync(serverChunksDir, { recursive: true });
+                }
                 const files = fs.readdirSync(serverChunksDir);
                 const serverFile = files.find(
                   (f) => f.startsWith("server_") && f.endsWith(".mjs")


### PR DESCRIPTION
Hey Jack,

I know you've been pretty much in the know but just to keep this documented

This pull request fixes the below 2 issues:

- `ENOENT: no such file or directory, scandir 'dist/server/chunks` error message in Vercel build process.
This error has been resolved by the force creation of the directory if needed.

- Vercel was handling Client static files in `dist/client/build` directory, and causing 404 errors in the browser

![](https://github.com/user-attachments/assets/e09c2b93-e2b4-4e76-bb6a-5b7bc0d1e1b8)

```javascript
 if (astroConfig.adapter?.name.includes("vercel")) {
            const outDirUrl = new URL(astroConfig.outDir.pathname, astroConfig.root);
            astroConfig.build.client = outDirUrl;
            finalDir = astroConfig.build.client.pathname;
          }
```

This code fixes this and adds all Astro and Qwik Javascript Client files in the `outdir` root now, which is where they need to be.

Static files in Vercel before:
![before fix ](https://github.com/user-attachments/assets/80a033f6-9679-498e-8864-512a74806d3e)

Static files in Vercel after:
![after fix](https://github.com/user-attachments/assets/748018a0-ef29-422d-bce7-07d3ec9faf72)

This has been tested on the below site types in Vercel, and should not impact how any other adapters are handling files.
This loads all Astro Javascript as expected and `clientrouter` etc are not impacted by this change and transition persist all fully work.
- fully SSG
- fully SSR
- Hybrid SSR SSG 

I did also test with other integrations and they load fine 
Examples:
- Astro Theme Toggle this has external javascript that loads and works
- Astro Icon this updates the integrations in the config and works
![](https://github.com/user-attachments/assets/62854f66-8bb0-4be9-b282-27a5a5e820d7)

 
![](https://github.com/user-attachments/assets/2a6e4054-dc47-4d7d-85bd-5dcdd7b6f7cc)
